### PR TITLE
feat: Alerting after synthetics are failing for 5 minutes; decrease priority of alerts

### DIFF
--- a/synthetic-tests/index.ts
+++ b/synthetic-tests/index.ts
@@ -28,9 +28,10 @@ const sendSecurelyHealthCheck = new datadog.SyntheticsTest(healthCheckName, {
   ],
   optionsList: {
     followRedirects: true,
+    minFailureDuration: 5, // minutes
     minLocationFailed: 2,
     monitorName: healthCheckName,
-    monitorPriority: 2,
+    monitorPriority: 4,
     tickEvery: 300, // seconds
     monitorOptions: {
       renotifyInterval: 60, // minutes
@@ -128,9 +129,10 @@ const sendSecurelyApiCheck = new datadog.SyntheticsTest(apiCheckName, {
   ],
   optionsList: {
     followRedirects: true,
+    minFailureDuration: 5, // minutes
     minLocationFailed: 2,
     monitorName: apiCheckName,
-    monitorPriority: 2,
+    monitorPriority: 4,
     tickEvery: 3600, // seconds
     monitorOptions: {
       renotifyInterval: 60, // minutes
@@ -210,9 +212,10 @@ const sendSecurelyApiCheck = new datadog.SyntheticsTest(apiCheckName, {
 //   ],
 //   optionsList: {
 //     followRedirects: true,
+//     minFailureDuration: 5, // minutes
 //     minLocationFailed: 2,
 //     monitorName: browserCheckName,
-//     monitorPriority: 2,
+//     monitorPriority: 4,
 //     tickEvery: 300,
 //     monitorOptions: {
 //       renotifyInterval: 120,


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Setting minFailureDuration to require synthetics to be failing for 5 minutes before alerting
- Reducing the priority of sendsecure.ly alerts to P4 to create low priority incidents in PagerDuty

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change