### PR TITLE
fix: Change units for minFailureDuration on synthetics

### DIFF
--- a/synthetic-tests/index.ts
+++ b/synthetic-tests/index.ts
@@ -28,7 +28,7 @@ const sendSecurelyHealthCheck = new datadog.SyntheticsTest(healthCheckName, {
   ],
   optionsList: {
     followRedirects: true,
-    minFailureDuration: 5, // minutes
+    minFailureDuration: 300, // seconds
     minLocationFailed: 2,
     monitorName: healthCheckName,
     monitorPriority: 4,
@@ -129,7 +129,7 @@ const sendSecurelyApiCheck = new datadog.SyntheticsTest(apiCheckName, {
   ],
   optionsList: {
     followRedirects: true,
-    minFailureDuration: 5, // minutes
+    minFailureDuration: 300, // seconds
     minLocationFailed: 2,
     monitorName: apiCheckName,
     monitorPriority: 4,
@@ -212,7 +212,7 @@ const sendSecurelyApiCheck = new datadog.SyntheticsTest(apiCheckName, {
 //   ],
 //   optionsList: {
 //     followRedirects: true,
-//     minFailureDuration: 5, // minutes
+//     minFailureDuration: 300, // seconds
 //     minLocationFailed: 2,
 //     monitorName: browserCheckName,
 //     monitorPriority: 4,


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- minFailureDuration is specified in seconds through pulumi, not minutes

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change